### PR TITLE
Document build blockers

### DIFF
--- a/BUILD_ANALYSIS.md
+++ b/BUILD_ANALYSIS.md
@@ -1,0 +1,14 @@
+# Build Analysis
+
+## Summary
+- The repository currently lacks the actual site assets (`index.html`, supporting markdown, etc.) in the working tree. Only a `files.zip` archive is present.
+- `vercel.json`'s build configuration targets `index.html`, so builds will fail because that file is missing at runtime.
+- The required assets exist inside `files.zip` and must be extracted (and committed) for successful deployment.
+
+## Evidence
+- Repository tree shows only documentation files plus `files.zip`; there is no tracked `index.html` at `HEAD`. This leaves the `main` entry in `package.json` and the Vercel build pointing at a missing file, causing deployment failures.【F:vercel.json†L1-L13】【589c4e†L1-L8】
+- The archive lists `index.html` and other assets that are not committed, confirming they are stuck inside the zip bundle instead of the repo itself.【b2a072†L1-L11】
+
+## Recommended Fix
+1. Extract the contents of `files.zip` into the repository so that `index.html` and other assets are tracked by Git.
+2. Commit the extracted files, remove the redundant archive, and ensure `vercel.json` continues to point to the correct entry file.


### PR DESCRIPTION
## Summary
- add a build analysis document capturing why the project fails to deploy in its current state

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_69081e25663c832a8dd0a9d386866d19