### PR TITLE
Add Prisma schema for Root Work Framework data models

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,366 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider  = "postgresql"
+  url       = env("DATABASE_URL")
+  directUrl = env("POSTGRES_URL_NON_POOLING")
+}
+
+enum SubscriptionTier {
+  FREE_TRIAL
+  INDIVIDUAL
+  PROFESSIONAL
+  ENTERPRISE
+}
+
+enum SubscriptionStatus {
+  TRIAL
+  ACTIVE
+  PAST_DUE
+  CANCELLED
+}
+
+enum BillingCycle {
+  MONTHLY
+  YEARLY
+}
+
+enum CourseEnrollmentStatus {
+  ENROLLED
+  IN_PROGRESS
+  COMPLETED
+  CANCELLED
+}
+
+enum WebinarRegistrationStatus {
+  REGISTERED
+  ATTENDED
+  NO_SHOW
+  CANCELLED
+}
+
+enum PaymentStatus {
+  PENDING
+  PAID
+  REFUNDED
+  FAILED
+}
+
+enum ConsultationStatus {
+  REQUESTED
+  SCHEDULED
+  COMPLETED
+  CANCELLED
+}
+
+enum ResourceType {
+  CHAPTER
+  WORKSHEET
+  TEMPLATE
+  GUIDE
+  OTHER
+}
+
+enum BlogPostStatus {
+  DRAFT
+  PUBLISHED
+  ARCHIVED
+}
+
+enum BookType {
+  LAW_OF_LEARNING
+  FINANCIAL_LITERACY
+  OTHER
+}
+
+enum UsageMetricType {
+  PAGE_VIEW
+  CLICK
+  CONVERSION
+  SIGNUP
+  LESSON_GENERATED
+  COURSE_ENROLLED
+  RESOURCE_DOWNLOADED
+  CUSTOM
+}
+
+model User {
+  id                     String                @id @default(cuid())
+  clerkId                String                @unique
+  email                  String                @unique
+  name                   String?
+  avatarUrl              String?
+  organization           String?
+  jobTitle               String?
+  subjectsTaught         String[]              @default([])
+  subscriptionTier       SubscriptionTier      @default(FREE_TRIAL)
+  subscriptionStatus     SubscriptionStatus    @default(TRIAL)
+  trialStartDate         DateTime?             
+  trialEndDate           DateTime?
+  stripeCustomerId       String?
+  phoneNumber            String?
+  address                String?
+  city                   String?
+  state                  String?
+  country                String?
+  postalCode             String?
+  lessonPlans            LessonPlan[]
+  subscriptions          Subscription[]
+  courseEnrollments      CourseEnrollment[]
+  webinarRegistrations   WebinarRegistration[]
+  consultationBookings   ConsultationBooking[]
+  resourceDownloads      ResourceDownload[]
+  blogPosts              BlogPost[]
+  usageMetrics           UsageMetric[]
+  emailSubscriptions     EmailSubscription[]
+  createdAt              DateTime              @default(now())
+  updatedAt              DateTime              @updatedAt
+}
+
+model Subscription {
+  id                     String             @id @default(cuid())
+  user                   User               @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId                 String
+  stripeSubscriptionId   String?            @unique
+  stripePriceId          String?
+  status                 SubscriptionStatus @default(TRIAL)
+  billingCycle           BillingCycle       @default(MONTHLY)
+  currentPeriodStart     DateTime?
+  currentPeriodEnd       DateTime?
+  trialEndsAt            DateTime?
+  cancelAtPeriodEnd      Boolean            @default(false)
+  cancelledAt            DateTime?
+  metadata               Json?
+  createdAt              DateTime           @default(now())
+  updatedAt              DateTime           @updatedAt
+}
+
+model LessonPlan {
+  id                     String           @id @default(cuid())
+  user                   User             @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId                 String
+  title                  String
+  subject                String
+  gradeLevel             String
+  duration               String?
+  standards              String[]         @default([])
+  objectives             String?
+  essentialQuestions     String?
+  rootActivities         String?
+  regulateActivity       String?
+  reflectActivity        String?
+  restoreActivity        String?
+  reconnectActivity      String?
+  differentiation        String?
+  assessmentStrategies   String?
+  materials              String?
+  extensions             String?
+  aiModel                String?
+  aiModelVersion         String?
+  tokensUsed             Int?
+  prompt                 String?
+  temperature            Float?
+  generationTimeMs       Int?
+  isPremium              Boolean          @default(false)
+  views                  Int              @default(0)
+  downloads              Int              @default(0)
+  notes                  String?
+  createdAt              DateTime         @default(now())
+  updatedAt              DateTime         @updatedAt
+}
+
+model Course {
+  id                     String            @id @default(cuid())
+  title                  String
+  slug                   String            @unique
+  description            String?
+  coverImageUrl          String?
+  ceuHours               Float             @default(0)
+  price                  Decimal?          @db.Decimal(10, 2)
+  currency               String            @default("USD")
+  thinkificCourseId      String?
+  thinkificUrl           String?
+  stripePriceId          String?
+  isPublished            Boolean           @default(false)
+  publishedAt            DateTime?
+  estimatedDuration      String?
+  learningObjectives     String?
+  prerequisites          String?
+  targetAudience         String?
+  chapters               CourseChapter[]
+  enrollments            CourseEnrollment[]
+  createdAt              DateTime          @default(now())
+  updatedAt              DateTime          @updatedAt
+}
+
+model CourseChapter {
+  id            String   @id @default(cuid())
+  course        Course   @relation(fields: [courseId], references: [id], onDelete: Cascade)
+  courseId      String
+  title         String
+  content       String?
+  order         Int
+  resources     String?
+  createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
+
+  @@unique([courseId, order])
+}
+
+model CourseEnrollment {
+  id                     String                   @id @default(cuid())
+  user                   User                     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId                 String
+  course                 Course                   @relation(fields: [courseId], references: [id], onDelete: Cascade)
+  courseId               String
+  status                 CourseEnrollmentStatus   @default(ENROLLED)
+  progress               Float                    @default(0)
+  certificateUrl         String?
+  completedAt            DateTime?
+  purchaseAmount         Decimal?                 @db.Decimal(10, 2)
+  currency               String                   @default("USD")
+  stripePaymentIntentId  String?
+  metadata               Json?
+  createdAt              DateTime                 @default(now())
+  updatedAt              DateTime                 @updatedAt
+}
+
+model Webinar {
+  id                     String            @id @default(cuid())
+  title                  String
+  description            String?
+  startTime              DateTime
+  endTime                DateTime?
+  meetingUrl             String?
+  recordingUrl           String?
+  platform               String?
+  hostName               String?
+  capacity               Int?
+  isPaid                 Boolean           @default(false)
+  price                  Decimal?          @db.Decimal(10, 2)
+  currency               String            @default("USD")
+  registrationDeadline   DateTime?
+  tags                   String[]          @default([])
+  registrations          WebinarRegistration[]
+  createdAt              DateTime          @default(now())
+  updatedAt              DateTime          @updatedAt
+}
+
+model WebinarRegistration {
+  id                     String                     @id @default(cuid())
+  webinar                Webinar                    @relation(fields: [webinarId], references: [id], onDelete: Cascade)
+  webinarId              String
+  user                   User?                      @relation(fields: [userId], references: [id])
+  userId                 String?
+  email                  String
+  fullName               String?
+  status                 WebinarRegistrationStatus  @default(REGISTERED)
+  paymentStatus          PaymentStatus              @default(PENDING)
+  stripePaymentIntentId  String?
+  attendedAt             DateTime?
+  notes                  String?
+  createdAt              DateTime                   @default(now())
+  updatedAt              DateTime                   @updatedAt
+}
+
+model ConsultationBooking {
+  id                     String              @id @default(cuid())
+  user                   User?               @relation(fields: [userId], references: [id])
+  userId                 String?
+  name                   String
+  email                  String
+  consultationType       String
+  description            String?
+  preferredDate          DateTime?
+  preferredTimeZone      String?
+  durationMinutes        Int?
+  status                 ConsultationStatus @default(REQUESTED)
+  meetingUrl             String?
+  price                  Decimal?           @db.Decimal(10, 2)
+  currency               String             @default("USD")
+  stripePaymentIntentId  String?
+  followUpActions        String?
+  notes                  String?
+  createdAt              DateTime           @default(now())
+  updatedAt              DateTime           @updatedAt
+}
+
+model EmailSubscription {
+  id                     String    @id @default(cuid())
+  user                   User?     @relation(fields: [userId], references: [id])
+  userId                 String?
+  email                  String
+  firstName              String?
+  lastName               String?
+  subscribedToNewsletter Boolean   @default(true)
+  subscribedToUpdates    Boolean   @default(false)
+  source                 String?
+  tags                   String[]  @default([])
+  metadata               Json?
+  unsubscribedAt         DateTime?
+  createdAt              DateTime  @default(now())
+  updatedAt              DateTime  @updatedAt
+
+  @@unique([email, source])
+}
+
+model BookWaitlist {
+  id               String    @id @default(cuid())
+  email            String
+  firstName        String?
+  lastName         String?
+  book             BookType  @default(LAW_OF_LEARNING)
+  interestLevel    String?
+  notifiedAt       DateTime?
+  metadata         Json?
+  createdAt        DateTime  @default(now())
+  updatedAt        DateTime  @updatedAt
+
+  @@unique([email, book])
+}
+
+model ResourceDownload {
+  id                String    @id @default(cuid())
+  user              User?     @relation(fields: [userId], references: [id])
+  userId            String?
+  email             String?
+  resourceName      String
+  resourceType      ResourceType
+  source            String?
+  ipAddress         String?
+  userAgent         String?
+  metadata          Json?
+  downloadedAt      DateTime  @default(now())
+}
+
+model BlogPost {
+  id                String          @id @default(cuid())
+  author            User?           @relation(fields: [authorId], references: [id])
+  authorId          String?
+  title             String
+  slug              String          @unique
+  excerpt           String?
+  content           String
+  seoTitle          String?
+  seoDescription    String?
+  status            BlogPostStatus  @default(DRAFT)
+  tags              String[]        @default([])
+  featuredImageUrl  String?
+  viewCount         Int             @default(0)
+  publishedAt       DateTime?
+  createdAt         DateTime        @default(now())
+  updatedAt         DateTime        @updatedAt
+}
+
+model UsageMetric {
+  id                String           @id @default(cuid())
+  user              User?            @relation(fields: [userId], references: [id])
+  userId            String?
+  metricType        UsageMetricType  @default(PAGE_VIEW)
+  value             Int              @default(1)
+  metadata          Json?
+  recordedAt        DateTime         @default(now())
+  createdAt         DateTime         @default(now())
+}


### PR DESCRIPTION
## Summary
- add a Prisma schema that captures the Root Work Framework domain, including user, subscription, lesson plan, and analytics models
- define supporting enums and relations for courses, webinars, consultations, and marketing data structures

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_69085240a128832a80f6b3a3d3d3cb76