### PR TITLE
Implement security hardening, SEO infrastructure, and data pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,41 @@
+# Environment variables — NEVER commit secrets
+.env
+.env.*
+.env.local
+.env.production
+.env.development
+
+# Vercel
+.vercel
+
+# Node
+node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+*.log
+
+# Operating System Files
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+Desktop.ini
+
+# IDE and Editor Files
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+.project
+.settings/
+*.sublime-project
+*.sublime-workspace
+
+# Temporary files
+*.tmp
+*.temp

--- a/.well-known/security.txt
+++ b/.well-known/security.txt
@@ -1,0 +1,10 @@
+Contact: mailto:hearn.sa@gmail.com
+Expires: 2027-01-01T00:00:00.000Z
+Policy: https://fg2g-rwfw.com/security-policy
+Preferred-Languages: en
+
+# Root Work Framework — Security Policy
+# If you discover a security vulnerability on fg2g-rwfw.com,
+# please report it responsibly by emailing hearn.sa@gmail.com.
+# We will respond within 5 business days and credit researchers
+# who follow responsible disclosure practices.

--- a/api/chat.js
+++ b/api/chat.js
@@ -1,0 +1,141 @@
+// In-memory rate limiter: 10 requests per minute per IP
+const rateLimit = new Map();
+const RATE_LIMIT_WINDOW = 60 * 1000;
+const RATE_LIMIT_MAX = 10;
+
+function isRateLimited(ip) {
+  const now = Date.now();
+  const entry = rateLimit.get(ip) || { count: 0, windowStart: now };
+  if (now - entry.windowStart > RATE_LIMIT_WINDOW) {
+    entry.count = 1;
+    entry.windowStart = now;
+  } else {
+    entry.count++;
+  }
+  rateLimit.set(ip, entry);
+  return entry.count > RATE_LIMIT_MAX;
+}
+
+const VALID_ROLES = ['user', 'assistant'];
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  // Rate limiting
+  const ip =
+    req.headers['x-forwarded-for']?.split(',')[0]?.trim() ||
+    req.socket?.remoteAddress ||
+    'unknown';
+  if (isRateLimited(ip)) {
+    return res.status(429).json({ error: 'Too many requests. Please wait a moment before trying again.' });
+  }
+
+  const { message, history = [] } = req.body || {};
+
+  // Input validation
+  if (!message || typeof message !== 'string') {
+    return res.status(400).json({ error: 'Message is required' });
+  }
+  if (message.length > 2000) {
+    return res.status(400).json({ error: 'Message too long. Please keep messages under 2000 characters.' });
+  }
+  if (!Array.isArray(history) || history.length > 20) {
+    return res.status(400).json({ error: 'Invalid request format.' });
+  }
+
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) {
+    return res.status(500).json({ error: 'Service configuration error. Please contact hearn.sa@gmail.com.' });
+  }
+
+  const systemPrompt = `You are Rooty 🌱, a friendly, warm, and knowledgeable assistant for the Root Work Framework (RWFW) — a healing-centered, trauma-informed pedagogical system created by Dr. Shawn A. Hearn, Ed.D., J.D.
+
+## About the Root Work Framework
+The Root Work Framework is a dual-purpose pedagogy that weaves academic rigor with healing-centered, biophilic practice. It transforms K-12 education by addressing the impacts of adverse childhood experiences (ACEs) through STEAM classrooms, Living Learning Labs, and restorative relationships.
+
+## The 5Rs Framework
+Five core phases, each building on the others:
+1. **Root** — Connect to purpose, culture, and place. Ground learning in students' identities and community contexts.
+2. **Regulate** — Prepare mind and body for learning through rituals, rhythms, and co-regulation practices.
+3. **Reflect** — Encourage self-assessment, metacognition, and meaning-making through structured reflection.
+4. **Restore** — Address harm, repair relationships, and rebuild trust through restorative practices.
+5. **Reconnect** — Apply learning to community and environment, fostering agency and civic engagement.
+
+## 3 Pillars
+Healing-Centered Pedagogy, Academic Rigor, and Biophilic Design.
+
+## SAMHSA Alignment
+Built on SAMHSA's 6 principles for trauma-informed care: Safety, Trustworthiness, Peer Support, Collaboration, Empowerment, and Cultural Responsiveness.
+
+## Who We Serve
+- K-12 Educators — Lesson planning tools, professional development, classroom resources grounded in the 5Rs
+- Homeschool Families — Living Learning Labs, journaling prompts, micro-economy projects
+- Charter Schools — Implementation sequences, fidelity tools, data tracking for whole-school adoption
+- Alternative Education — Healing-centered routines for detention, therapeutic, and justice-involved youth settings
+- Juvenile Justice Programs — Restorative practices, therapeutic horticulture, reentry-focused curricula
+- Teacher Preparation Programs — Graduate-level coursework and healing-centered instructional frameworks
+- Community Centers — After-school programs and family engagement workshops
+
+## The Root Work Ecosystem
+- AI Lesson Generator — Generate healing-centered, standards-aligned lesson plans using the 5Rs
+- Professional Development — Online courses, workshops, speaking engagements nationwide
+- Resource Library — Toolkits, templates, rubrics, and research-backed materials
+- Living Learning Labs — Therapeutic gardens, sustainability projects, biophilic learning spaces
+- Published Works — Evidence-based books by Dr. Shawn A. Hearn
+- Community Network — Educators and advocates advancing Rerooted Learning
+
+## About Dr. Shawn A. Hearn
+Dr. Shawn A. Hearn, Ed.D., J.D., is a legal and educational professional, U.S. military veteran, and founder of Community Exceptional Children's Services (CECS). With certifications in Secondary Education, Educational Leadership, and Special Education (EBD endorsement), Dr. Hearn brings decades of experience serving students with disabilities, justice-involved youth, and communities affected by trauma. He authored "From Garden to Growth: Building Trauma-Informed STEAM Classrooms through Living Learning Labs" and "The Law of Learning: Education, Policy, and Legal Frameworks in K-12 Schools."
+
+## Contact
+Email: hearn.sa@gmail.com
+
+## Your Behavior
+- Respond in a warm, concise, healing-centered tone that mirrors the framework's values
+- Keep answers brief — 2-4 sentences for simple questions, a short paragraph for complex ones
+- If someone asks to schedule a consultation, book a meeting, set up a call, or talk to Dr. Hearn, include the exact token [OPEN_SCHEDULER] on its own line in your reply
+- Only answer questions about the Root Work Framework, its content, Dr. Hearn, and related educational topics
+- If asked something outside your scope, gently redirect to relevant RWFW topics`;
+
+  // Sanitize history: only allow valid roles and string content
+  const messages = [
+    ...history
+      .filter(h => h && VALID_ROLES.includes(h.role) && typeof h.content === 'string')
+      .map(h => ({ role: h.role, content: h.content.slice(0, 2000) })),
+    { role: 'user', content: message }
+  ];
+
+  try {
+    const response = await fetch('https://api.anthropic.com/v1/messages', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': apiKey,
+        'anthropic-version': '2023-06-01'
+      },
+      body: JSON.stringify({
+        model: 'claude-haiku-4-5-20251001',
+        max_tokens: 512,
+        system: systemPrompt,
+        messages
+      })
+    });
+
+    if (!response.ok) {
+      const errText = await response.text();
+      console.error('Anthropic API error:', response.status, errText);
+      return res.status(502).json({ error: 'Unable to reach assistant. Please try again.' });
+    }
+
+    const data = await response.json();
+    const reply = data.content?.[0]?.text ||
+      "I'm not sure how to answer that. Feel free to email hearn.sa@gmail.com for direct support.";
+
+    return res.status(200).json({ reply });
+  } catch (err) {
+    console.error('Chat handler error:', err);
+    return res.status(500).json({ error: 'Something went wrong. Please try again shortly.' });
+  }
+}

--- a/api/consultation.js
+++ b/api/consultation.js
@@ -1,0 +1,55 @@
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const { name, email, phone, organization, interest, message } = req.body || {};
+
+  if (!name || typeof name !== 'string' || name.trim().length === 0) {
+    return res.status(400).json({ error: 'Name is required.' });
+  }
+  if (!email || typeof email !== 'string' || !email.includes('@')) {
+    return res.status(400).json({ error: 'Valid email address is required.' });
+  }
+  if (!message || typeof message !== 'string' || message.trim().length === 0) {
+    return res.status(400).json({ error: 'Message is required.' });
+  }
+  if (message.length > 5000) {
+    return res.status(400).json({ error: 'Message too long (max 5000 characters).' });
+  }
+
+  const webhookUrl = process.env.N8N_CONSULTATION_WEBHOOK;
+  if (!webhookUrl) {
+    console.error('N8N_CONSULTATION_WEBHOOK not configured');
+    return res.status(500).json({ error: 'Service configuration error. Please contact hearn.sa@gmail.com.' });
+  }
+
+  try {
+    const payload = {
+      name: name.trim().slice(0, 100),
+      email: email.trim().toLowerCase().slice(0, 254),
+      phone: (phone || '').trim().slice(0, 20),
+      organization: (organization || '').trim().slice(0, 200),
+      interest: (interest || '').trim().slice(0, 100),
+      message: message.trim().slice(0, 5000),
+      timestamp: new Date().toISOString(),
+      source: 'fg2g-rwfw.com'
+    };
+
+    const n8nRes = await fetch(webhookUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    });
+
+    if (!n8nRes.ok) {
+      console.error('n8n consultation webhook error:', n8nRes.status);
+      return res.status(502).json({ error: 'Unable to submit request. Please try again.' });
+    }
+
+    return res.status(200).json({ success: true, message: 'Thank you! We\'ll be in touch within 2 business days.' });
+  } catch (err) {
+    console.error('Consultation handler error:', err);
+    return res.status(500).json({ error: 'Something went wrong. Please try again shortly.' });
+  }
+}

--- a/api/newsletter.js
+++ b/api/newsletter.js
@@ -1,0 +1,49 @@
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const { name, email, role } = req.body || {};
+
+  if (!email || typeof email !== 'string' || !email.includes('@')) {
+    return res.status(400).json({ error: 'Valid email address is required.' });
+  }
+  if (email.length > 254) {
+    return res.status(400).json({ error: 'Invalid email address.' });
+  }
+  if (name && typeof name === 'string' && name.length > 100) {
+    return res.status(400).json({ error: 'Name too long.' });
+  }
+
+  const webhookUrl = process.env.N8N_NEWSLETTER_WEBHOOK;
+  if (!webhookUrl) {
+    console.error('N8N_NEWSLETTER_WEBHOOK not configured');
+    return res.status(500).json({ error: 'Service configuration error. Please contact hearn.sa@gmail.com.' });
+  }
+
+  try {
+    const payload = {
+      name: (name || '').trim().slice(0, 100),
+      email: email.trim().toLowerCase(),
+      role: (role || 'other').trim().slice(0, 50),
+      timestamp: new Date().toISOString(),
+      source: 'fg2g-rwfw.com'
+    };
+
+    const n8nRes = await fetch(webhookUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    });
+
+    if (!n8nRes.ok) {
+      console.error('n8n newsletter webhook error:', n8nRes.status);
+      return res.status(502).json({ error: 'Unable to process signup. Please try again.' });
+    }
+
+    return res.status(200).json({ success: true, message: 'You\'re subscribed! Check your inbox for a welcome email.' });
+  } catch (err) {
+    console.error('Newsletter handler error:', err);
+    return res.status(500).json({ error: 'Something went wrong. Please try again shortly.' });
+  }
+}

--- a/api/unsubscribe.js
+++ b/api/unsubscribe.js
@@ -1,0 +1,65 @@
+export default async function handler(req, res) {
+  if (req.method !== 'GET') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const { token } = req.query || {};
+
+  if (!token || typeof token !== 'string' || token.length < 8) {
+    return res.status(400).send(renderPage('Invalid unsubscribe link. Please contact hearn.sa@gmail.com for help.', false));
+  }
+
+  const webhookUrl = process.env.N8N_UNSUBSCRIBE_WEBHOOK;
+  if (!webhookUrl) {
+    console.error('N8N_UNSUBSCRIBE_WEBHOOK not configured');
+    return res.status(500).send(renderPage('Service error. Please contact hearn.sa@gmail.com.', false));
+  }
+
+  try {
+    const n8nRes = await fetch(webhookUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ token: token.slice(0, 128), timestamp: new Date().toISOString() })
+    });
+
+    if (!n8nRes.ok) {
+      console.error('n8n unsubscribe webhook error:', n8nRes.status);
+      return res.status(502).send(renderPage('Unable to process your request. Please try again or email hearn.sa@gmail.com.', false));
+    }
+
+    res.setHeader('Content-Type', 'text/html');
+    return res.status(200).send(renderPage('You\'ve been successfully unsubscribed from the Root Work Framework newsletter. We\'re sorry to see you go. You can re-subscribe anytime at fg2g-rwfw.com.', true));
+  } catch (err) {
+    console.error('Unsubscribe handler error:', err);
+    return res.status(500).send(renderPage('Something went wrong. Please email hearn.sa@gmail.com for help.', false));
+  }
+}
+
+function renderPage(message, success) {
+  const color = success ? '#3B523A' : '#8B0000';
+  const icon = success ? '✅' : '⚠️';
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>${success ? 'Unsubscribed' : 'Error'} — Root Work Framework</title>
+  <style>
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #F2F4CA; display: flex; align-items: center; justify-content: center; min-height: 100vh; margin: 0; }
+    .card { background: #fff; border-radius: 12px; padding: 48px 40px; max-width: 480px; text-align: center; box-shadow: 0 4px 24px rgba(0,0,0,0.08); }
+    .icon { font-size: 48px; margin-bottom: 16px; }
+    h1 { color: #082A19; font-size: 24px; margin: 0 0 12px; }
+    p { color: #555; line-height: 1.6; margin: 0 0 24px; }
+    a { display: inline-block; background: ${color}; color: #fff; text-decoration: none; padding: 12px 28px; border-radius: 999px; font-weight: 600; }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <div class="icon">${icon}</div>
+    <h1>Root Work Framework</h1>
+    <p>${message}</p>
+    <a href="https://fg2g-rwfw.com">Return Home</a>
+  </div>
+</body>
+</html>`;
+}

--- a/index.html
+++ b/index.html
@@ -5,7 +5,51 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Root Work Framework – Rerooted Learning: Where Academics and Healing Grow Together</title>
     <meta name="description" content="The Root Work Framework is a dual-purpose pedagogy that weaves academic rigor with healing-centered, biophilic practice. Built on the 5Rs Framework (Root, Regulate, Reflect, Restore, Reconnect). Serving K-12 educators, homeschool families, charter schools, and alternative education programs.">
-    
+
+    <!-- Canonical URL -->
+    <link rel="canonical" href="https://fg2g-rwfw.com/" />
+
+    <!-- Favicon -->
+    <link rel="icon" type="image/svg+xml" href="/icons/tree-simple.svg" />
+    <link rel="icon" type="image/png" href="/icons/root.png" />
+    <link rel="apple-touch-icon" href="/icons/root.png" />
+
+    <!-- Open Graph -->
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="Root Work Framework" />
+    <meta property="og:title" content="Root Work Framework – Rerooted Learning: Where Academics and Healing Grow Together" />
+    <meta property="og:description" content="A healing-centered, trauma-informed pedagogy built on the 5Rs Framework. Tools and resources for K-12 educators, homeschool families, charter schools, and alternative education programs." />
+    <meta property="og:image" content="https://fg2g-rwfw.com/icons/root.png" />
+    <meta property="og:url" content="https://fg2g-rwfw.com/" />
+
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Root Work Framework – Rerooted Learning" />
+    <meta name="twitter:description" content="A healing-centered, trauma-informed pedagogy built on the 5Rs Framework. For K-12 educators, homeschool families, and alternative education programs." />
+    <meta name="twitter:image" content="https://fg2g-rwfw.com/icons/root.png" />
+
+    <!-- JSON-LD Organization Schema -->
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Organization",
+      "name": "Root Work Framework",
+      "url": "https://fg2g-rwfw.com/",
+      "logo": "https://fg2g-rwfw.com/icons/root.png",
+      "description": "A healing-centered, trauma-informed pedagogical system created by Dr. Shawn A. Hearn, Ed.D., J.D. Built on the 5Rs Framework: Root, Regulate, Reflect, Restore, Reconnect.",
+      "email": "hearn.sa@gmail.com",
+      "founder": {
+        "@type": "Person",
+        "name": "Dr. Shawn A. Hearn",
+        "honorificPrefix": "Dr.",
+        "jobTitle": "Founder & Educational Consultant"
+      },
+      "sameAs": [
+        "https://www.youtube.com/@rootworkframework"
+      ]
+    }
+    </script>
+
     <style>
         /* ============================================
            ROOT WORK FRAMEWORK BRAND STANDARDS v1.0
@@ -1781,47 +1825,51 @@
             });
             
             // Handle form submission
-            form.addEventListener('submit', (e) => {
+            form.addEventListener('submit', async (e) => {
                 e.preventDefault();
-                
-                // Get form data
+
+                const submitBtn = form.querySelector('.newsletter-submit');
+                if (submitBtn) { submitBtn.disabled = true; submitBtn.textContent = 'Subscribing…'; }
+
                 const formData = {
                     name: document.getElementById('newsletter-name').value,
                     email: document.getElementById('newsletter-email').value,
-                    role: document.getElementById('newsletter-role').value,
-                    timestamp: new Date().toISOString()
+                    role: document.getElementById('newsletter-role').value
                 };
-                
-                // TODO: Replace with actual backend API call in production
-                // Example: fetch('/api/newsletter/subscribe', { method: 'POST', body: JSON.stringify(formData) })
-                // For demonstration only - do not use in production as it exposes user data
-                if (window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1') {
-                    console.log('Newsletter Signup (demo only):', formData);
-                    // Store in localStorage for demonstration purposes only
-                    let signups = JSON.parse(localStorage.getItem('newsletterSignups') || '[]');
-                    signups.push(formData);
-                    localStorage.setItem('newsletterSignups', JSON.stringify(signups));
+
+                try {
+                    const res = await fetch('/api/newsletter', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify(formData)
+                    });
+                    if (!res.ok) {
+                        const errData = await res.json().catch(() => ({}));
+                        throw new Error(errData.error || 'Signup failed. Please try again.');
+                    }
+                } catch (err) {
+                    if (submitBtn) { submitBtn.disabled = false; submitBtn.textContent = 'Join the Movement'; }
+                    alert(err.message || 'Something went wrong. Please try again.');
+                    return;
                 }
-                
+
                 // Show success message
                 form.style.display = 'none';
                 successMessage.classList.add('active');
-                
+
                 // Hide trigger button
                 trigger.classList.add('hidden');
-                
-                // Constants for timing
-                const SUCCESS_DISPLAY_TIME = 3000; // Show success message for 3 seconds
-                const FORM_RESET_DELAY = 500; // Wait for modal close animation before resetting
-                
-                // Close modal after showing success message
+
+                const SUCCESS_DISPLAY_TIME = 3000;
+                const FORM_RESET_DELAY = 500;
+
                 setTimeout(() => {
                     closeModal();
-                    // Reset form after modal close animation completes
                     setTimeout(() => {
                         form.style.display = 'flex';
                         successMessage.classList.remove('active');
                         form.reset();
+                        if (submitBtn) { submitBtn.disabled = false; submitBtn.textContent = 'Join the Movement'; }
                     }, FORM_RESET_DELAY);
                 }, SUCCESS_DISPLAY_TIME);
             });
@@ -1959,31 +2007,37 @@
             });
             
             // Handle form submission
-            form.addEventListener('submit', (e) => {
+            form.addEventListener('submit', async (e) => {
                 e.preventDefault();
-                
-                // Get form data
+
+                const submitBtn = form.querySelector('.consultation-submit');
+                if (submitBtn) { submitBtn.disabled = true; submitBtn.textContent = 'Submitting…'; }
+
                 const formData = {
                     name: document.getElementById('consultation-name').value,
                     email: document.getElementById('consultation-email').value,
                     phone: document.getElementById('consultation-phone').value,
                     organization: document.getElementById('consultation-organization').value,
                     interest: document.getElementById('consultation-interest').value,
-                    message: document.getElementById('consultation-message').value,
-                    timestamp: new Date().toISOString()
+                    message: document.getElementById('consultation-message').value
                 };
-                
-                // TODO: Replace with actual backend API call in production
-                // Example: fetch('/api/consultation/request', { method: 'POST', body: JSON.stringify(formData) })
-                // For demonstration only - do not use in production as it exposes user data
-                if (window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1') {
-                    console.log('Consultation Request (demo only):', formData);
-                    // Store in localStorage for demonstration purposes only
-                    let requests = JSON.parse(localStorage.getItem('consultationRequests') || '[]');
-                    requests.push(formData);
-                    localStorage.setItem('consultationRequests', JSON.stringify(requests));
+
+                try {
+                    const res = await fetch('/api/consultation', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify(formData)
+                    });
+                    if (!res.ok) {
+                        const errData = await res.json().catch(() => ({}));
+                        throw new Error(errData.error || 'Submission failed. Please try again.');
+                    }
+                } catch (err) {
+                    if (submitBtn) { submitBtn.disabled = false; submitBtn.textContent = 'Request Consultation'; }
+                    alert(err.message || 'Something went wrong. Please try again.');
+                    return;
                 }
-                
+
                 // Show success message
                 form.style.display = 'none';
                 successMessage.classList.add('active');
@@ -2000,10 +2054,12 @@
                         form.style.display = 'flex';
                         successMessage.classList.remove('active');
                         form.reset();
+                        const submitBtn = form.querySelector('.consultation-submit');
+                        if (submitBtn) { submitBtn.disabled = false; submitBtn.textContent = 'Request Consultation'; }
                     }, FORM_RESET_DELAY);
                 }, SUCCESS_DISPLAY_TIME);
             });
-            
+
             // Close on ESC key
             document.addEventListener('keydown', (e) => {
                 if (e.key === 'Escape' && modal.classList.contains('active')) {
@@ -2245,5 +2301,8 @@
             if (front && back) back.src = front.src;
         })();
     </script>
+
+    <!-- Vercel Analytics -->
+    <script defer src="/_vercel/insights/script.js"></script>
 </body>
 </html>

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,5 @@
+User-agent: *
+Allow: /
+Disallow: /api/
+
+Sitemap: https://fg2g-rwfw.com/sitemap.xml

--- a/savannah-initiative.html
+++ b/savannah-initiative.html
@@ -3,7 +3,22 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>RootWork Framework — An Invitation to Partner</title>
+  <title>Savannah Initiative — Root Work Framework Partnership</title>
+  <meta name="description" content="The Savannah Initiative is an invitation for schools, districts, and community organizations to partner with the Root Work Framework — bringing healing-centered, trauma-informed pedagogy to students across Georgia and beyond." />
+  <link rel="canonical" href="https://fg2g-rwfw.com/savannah-initiative" />
+  <link rel="icon" type="image/svg+xml" href="/icons/tree-simple.svg" />
+  <link rel="icon" type="image/png" href="/icons/root.png" />
+  <link rel="apple-touch-icon" href="/icons/root.png" />
+  <meta property="og:type" content="website" />
+  <meta property="og:site_name" content="Root Work Framework" />
+  <meta property="og:title" content="Savannah Initiative — Root Work Framework Partnership" />
+  <meta property="og:description" content="An invitation for schools, districts, and community organizations to partner with the Root Work Framework and bring healing-centered learning to your community." />
+  <meta property="og:image" content="https://fg2g-rwfw.com/icons/root.png" />
+  <meta property="og:url" content="https://fg2g-rwfw.com/savannah-initiative" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Savannah Initiative — Root Work Framework" />
+  <meta name="twitter:description" content="An invitation to partner with the Root Work Framework and bring healing-centered learning to your community." />
+  <meta name="twitter:image" content="https://fg2g-rwfw.com/icons/root.png" />
   <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@400;500;600;700&family=Jost:wght@300;400;500;600&display=swap" rel="stylesheet" />
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -231,6 +246,13 @@
   </style>
 </head>
 <body>
+<nav style="background:#082A19;padding:12px 24px;display:flex;align-items:center;gap:12px;position:sticky;top:0;z-index:100;">
+  <img src="/icons/tree-simple.svg" alt="Root Work Framework" width="28" height="28" style="opacity:.9;" />
+  <span style="font-family:'Jost',sans-serif;font-size:13px;font-weight:500;color:rgba(212,200,98,.85);letter-spacing:.04em;">Root Work Framework</span>
+  <a href="/" style="margin-left:auto;font-family:'Jost',sans-serif;font-size:13px;font-weight:500;color:#D4C862;text-decoration:none;display:flex;align-items:center;gap:6px;">
+    <span aria-hidden="true">←</span> Back to Home
+  </a>
+</nav>
 <div class="email-wrapper">
 
   <!-- HEADER -->
@@ -434,5 +456,8 @@
   </div>
 
 </div>
+
+<!-- Vercel Analytics -->
+<script defer src="/_vercel/insights/script.js"></script>
 </body>
 </html>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://fg2g-rwfw.com/</loc>
+    <lastmod>2026-02-23</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://fg2g-rwfw.com/savannah-initiative</loc>
+    <lastmod>2026-02-23</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+</urlset>

--- a/vercel.json
+++ b/vercel.json
@@ -20,7 +20,21 @@
         { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
         { "key": "X-Content-Type-Options", "value": "nosniff" },
         { "key": "X-Frame-Options", "value": "SAMEORIGIN" },
-        { "key": "Permissions-Policy", "value": "geolocation=(), microphone=(), camera=()" }
+        { "key": "Permissions-Policy", "value": "geolocation=(), microphone=(self), camera=()" },
+        { "key": "Strict-Transport-Security", "value": "max-age=31536000; includeSubDomains" },
+        { "key": "Content-Security-Policy", "value": "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' fonts.googleapis.com; font-src fonts.gstatic.com; img-src 'self' data: blob:; connect-src 'self' https://api.anthropic.com; media-src 'self'" }
+      ]
+    },
+    {
+      "source": "/icons/(.*)",
+      "headers": [
+        { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }
+      ]
+    },
+    {
+      "source": "/(.*)\\.(?:png|jpg|jpeg|gif|webp|svg|ico|woff|woff2)$",
+      "headers": [
+        { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }
       ]
     }
   ]


### PR DESCRIPTION
## Summary

Implements all planned upgrades across three domains — security hardening, SEO infrastructure, and data pipeline wiring — in a single wave.

### 🔴 Security (closes #14 #15 #16 #17 #18 #19)
- **[S1]** Fix `Permissions-Policy: microphone=(self)` — unblocks voice input button in Rooty chatbot
- **[S2]** Rate limiting: 10 requests/min per IP on `/api/chat`, returns HTTP 429
- **[S3]** Input validation: message ≤ 2000 chars, history ≤ 20 items, role allowlist filter
- **[S4]** HSTS (`max-age=31536000; includeSubDomains`) + Content-Security-Policy headers
- **[S5]** Hardened `.gitignore` (`.env*`, `node_modules/`, OS/IDE files) + `.well-known/security.txt`
- **[S6]** Immutable `Cache-Control` headers for `/icons/*` and static assets

### 🟡 SEO (closes #20 #21 #22 #23 #24 #25 #26)
- **[E1]** Open Graph + Twitter Card meta tags on both pages
- **[E2]** `robots.txt` (Disallow: /api/) + `sitemap.xml` (index priority 1.0, savannah 0.8)
- **[E3]** JSON-LD Organization schema in `index.html` head
- **[E4]** SVG favicon + apple-touch-icon on both pages
- **[E5]** Canonical URL + meta description on `savannah-initiative.html`
- **[E6]** Sticky "← Back to Home" navigation bar on Savannah Initiative page
- **[E7]** Vercel Analytics script (`/_vercel/insights/script.js`) on both pages

### 🟠 Data Pipeline (closes #27 #28 #30)
- **[D1]** `api/newsletter.js` — POST to `N8N_NEWSLETTER_WEBHOOK`; newsletter form wired to call it
- **[D2]** `api/consultation.js` — POST to `N8N_CONSULTATION_WEBHOOK`; consultation form wired to call it
- **[D4]** `api/unsubscribe.js` — GET with `?token=` → n8n → branded HTML confirmation page

### ⚠️ Action required before forms work
Set these environment variables in the **Vercel dashboard** (Settings → Environment Variables):
| Variable | Description |
|----------|-------------|
| `N8N_NEWSLETTER_WEBHOOK` | n8n webhook URL for newsletter signup handler |
| `N8N_CONSULTATION_WEBHOOK` | n8n webhook URL for consultation request handler |
| `N8N_UNSUBSCRIBE_WEBHOOK` | n8n webhook URL for unsubscribe handler |

Issue #29 (D3 — Agentic Weekly Newsletter Generator) is a pure n8n workflow build — no repo files needed.

## Test plan
- [ ] Voice mic button works after deploy (Permissions-Policy fixed)
- [ ] `/api/chat` returns 429 after 10 rapid requests
- [ ] Message > 2000 chars returns 400
- [ ] `curl -I https://fg2g-rwfw.com` shows HSTS + CSP headers
- [ ] `https://fg2g-rwfw.com/robots.txt` returns 200
- [ ] `https://fg2g-rwfw.com/sitemap.xml` returns 200
- [ ] OG preview at https://opengraph.xyz shows title + image
- [ ] Savannah page shows sticky back-nav
- [ ] Vercel Analytics appearing in dashboard after deploy
- [ ] Set n8n webhook env vars, then test both forms submit successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)